### PR TITLE
Prevent packages being downloaded unnecessarily

### DIFF
--- a/salt/_states/cacophony.py
+++ b/salt/_states/cacophony.py
@@ -9,6 +9,9 @@ def pkg_installed_from_github(name, version, systemd_reload=True):
     systemd.
     """
 
+    # Guard against versions being converted to floats in YAML parsing.
+    assert isinstance(version, basestring), "version must be a string"
+
     installed_version = __salt__['pkg.version'](name)
     if installed_version == version:
         return {

--- a/salt/pi/attiny-controller/init.sls
+++ b/salt/pi/attiny-controller/init.sls
@@ -1,7 +1,7 @@
 attiny-controller-pkg:
   cacophony.pkg_installed_from_github:
     - name: attiny-controller
-    - version: 2.0
+    - version: "2.0"
 
 attiny-controller-service:
   service.running:

--- a/salt/pi/audiobait/init.sls
+++ b/salt/pi/audiobait/init.sls
@@ -1,7 +1,7 @@
 audiobait-pkg:
   cacophony.pkg_installed_from_github:
     - name: audiobait
-    - version: 1.0
+    - version: "1.0"
 
 /etc/audiobait.yaml:
   file.managed:

--- a/salt/pi/event-reporter.sls
+++ b/salt/pi/event-reporter.sls
@@ -1,7 +1,7 @@
 event-reporter-pkg:
   cacophony.pkg_installed_from_github:
     - name: event-reporter
-    - version: 1.0
+    - version: "1.0"
 
 event-reporter-service:
   service.running:

--- a/salt/pi/management-interface/init.sls
+++ b/salt/pi/management-interface/init.sls
@@ -1,7 +1,7 @@
 management-interface-pkg:
   cacophony.pkg_installed_from_github:
     - name: management-interface
-    - version: 0.1
+    - version: "0.1"
 
 management-interface-service:
   service.running:

--- a/salt/pi/thermal-recorder/init.sls
+++ b/salt/pi/thermal-recorder/init.sls
@@ -1,7 +1,7 @@
 thermal-recorder-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-recorder
-    - version: 1.8
+    - version: "1.8"
 
 # Install support for exFAT & NTFS filesystems (for USB drives)
 extra-filesystems:

--- a/salt/pi/thermal-uploader/init.sls
+++ b/salt/pi/thermal-uploader/init.sls
@@ -1,7 +1,7 @@
 thermal-uploader-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-uploader
-    - version: 1.5
+    - version: "1.5"
 
 thermal-uploader-service:
   service.running:


### PR DESCRIPTION
Version numbers were being converted to floating point values during
YAML parsing which caused cacophony.pkg_installed_from_github to not
think the correct version of a package was installed and therefore
download it again.

All version numbers in states have been forced to strings and
pkg_installed_from_github now asserts that the version number it gets is
a string.

On an up-to-date pi with a good network connection this brings the
state.apply time down from 61.7s to 11.9s.