### PR TITLE
thermal-recorder 1.11 and introduce new grains

### DIFF
--- a/salt/pi/thermal-recorder/init.sls
+++ b/salt/pi/thermal-recorder/init.sls
@@ -1,7 +1,11 @@
 thermal-recorder-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-recorder
+    {% if salt['grains.get']('cacophony:recorder-beta') %}
+    - version: "1.11"
+    {% else %}
     - version: "1.10"
+    {% endif %}
 
 # Install support for exFAT & NTFS filesystems (for USB drives)
 extra-filesystems:
@@ -20,7 +24,11 @@ cp-volume-mount:
 
 /etc/thermal-recorder.yaml:
   file.managed:
+    {% if salt['grains.get']('cacophony:recorder-beta') %}
+    - source: salt://pi/thermal-recorder/thermal-recorder-1.11.yaml.jinja
+    {% else %}
     - source: salt://pi/thermal-recorder/thermal-recorder.yaml.jinja
+    {% endif %}
     - template: jinja
 
 /etc/leptond.yaml:

--- a/salt/pi/thermal-recorder/thermal-recorder-1.11.yaml.jinja
+++ b/salt/pi/thermal-recorder/thermal-recorder-1.11.yaml.jinja
@@ -1,0 +1,83 @@
+# Directory to place CPTV output files.
+output-dir: "/var/spool/cptv"
+
+# Mininum disk space required to record, in MB
+min-disk-space: 200
+
+recorder:
+    # Time to record before motion was detected.
+    preview-secs: 1
+
+    # Minimum length to keep recording after motion is detected.
+    min-secs: 10
+
+    # Maximum total video length.
+    max-secs: 600
+
+{% set window = salt['grains.get']('cacophony:recording-window') %}
+{%- if window -%}
+{%- set win_start, win_end = window.split('-') -%}
+    window-start: '{{ win_start }}'
+    window-end: '{{ win_end }}'
+{% endif %}
+
+# Motion detection parameters
+motion:
+    # Movement below raw temperatures of this value will not activate
+    # motion detection.
+    temp-thresh: 3000
+
+    # Minimum raw temperature difference between recent frames to
+    # trigger motion detection.
+    delta-thresh: 50
+
+    # Number of pixels which must show delta-thresh change before
+    # motion detection event will be triggered.
+    count-thresh: 3
+
+    # Suppress motion detection if more than this percentage of the
+    # frame appears to change. This helps avoid false positives when
+    # the camera is recalibrating.
+    nonzero-max-percent: 50
+
+    # When working out which pixels have changed it tries to compare
+    # the current frame with one recorded this many frames ago. If there
+    # aren't this many frames (eg since a recalibration) then it will use
+    # the oldest frame it has after the last 'bad' frame.
+    frame-compare-gap: 45
+
+    # When working out if motion has occured only look at a single frame diff (default).
+    # If set to false then it looks as two sequential frame diffs and only considers
+    # pixels that have changed in both diffs.  However, rats etc can move so fast that
+    # the pixels they are in can differ between frames so it is recommend to use only one diff
+    # frame and increase the number of trigger-frames instead.
+    one-diff-only: true
+
+    # No. of sequential frames that must have motion detected before a recording will
+    # start.   Having this > 1 helps prevent false positives causing recordings
+    trigger-frames: 2
+
+    # If set to true, then the frame diff only considers pixels that have become warmer.
+    # Otherwise there are ghost pixels where the animal used to be but isn't now.
+    warmer-only: true
+
+    # Verbose gives lots of information on which pixels are detected as changed.
+    verbose: false
+
+# Throttling of recording (for wind or animal in trap)
+throttler:
+    # set to false if you do not want to apply throttling
+    apply-throttling: true
+
+    # start throttling after this many seconds of recording
+    throttle-after-secs: 600
+
+    # record an occasional sparse recording after this many seconds of throttling during which
+    # time no recordings have been made
+    sparse-after-secs: 3600
+
+    # max length of sparse recording should be.
+    # if =0 then no occasional recordings will be made
+    # if value is less than the min recording length then it will set to min recording length
+    sparse-length-secs: 30
+

--- a/salt/pi/thermal-recorder/thermal-recorder-1.11.yaml.jinja
+++ b/salt/pi/thermal-recorder/thermal-recorder-1.11.yaml.jinja
@@ -6,7 +6,7 @@ min-disk-space: 200
 
 recorder:
     # Time to record before motion was detected.
-    preview-secs: 1
+    preview-secs: {{ salt['grains.get']('cacophony:recorder-preview', 1) }}
 
     # Minimum length to keep recording after motion is detected.
     min-secs: 10

--- a/salt/pi/thermal-recorder/thermal-recorder.yaml.jinja
+++ b/salt/pi/thermal-recorder/thermal-recorder.yaml.jinja
@@ -2,7 +2,7 @@
 output-dir: "/var/spool/cptv"
 
 # Time to record before motion was detected.
-preview-secs: 1
+preview-secs: {{ salt['grains.get']('cacophony:recorder-preview', 1) }}
 
 # Minimum length to keep recording after motion is detected.
 min-secs: 10


### PR DESCRIPTION
Devices with `cacophony:recorder-beta` set will receive thermal-recorder 1.11.  This is the first version to use the Lepton telemetry data.

A `cacophony:recorder-preview` grain has also been added. This lets us set the thermal-recorder preview time on a per device basis.