### PR TITLE
newest version telegraf, for monitoring processes handy

### DIFF
--- a/salt/server/telegraf/map.jinja
+++ b/salt/server/telegraf/map.jinja
@@ -5,7 +5,7 @@
   },
   'server-test-*': {
     'dbserver': '10.138.112.159',
-    'version': '1.5.2-1',
+    'version': '1.9.3-1',
   },
 },
 grain='id',


### PR DESCRIPTION
The newest *telegraf* has de plugin procstat_lookup, with which you can monitor number of processes per application. We than can make an alert when it is zero.