### PR TITLE
minio server

### DIFF
--- a/salt/server/salt.sls
+++ b/salt/server/salt.sls
@@ -1,9 +1,9 @@
 salt_pkgrepo:
   pkgrepo.managed:
     - humanname: SaltStack
-    - name: deb https://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2 bionic main
+    - name: deb https://repo.saltstack.com/apt/ubuntu/18.04/amd64/2018.3 bionic main
     - file: /etc/apt/sources.list.d/saltstack.list
-    #- key_url: https://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2/SALTSTACK-GPG-KEY.pub
+    #- key_url: https://repo.saltstack.com/apt/ubuntu/18.04/amd64/2018.3/SALTSTACK-GPG-KEY.pub
     - clean_file: True
     - refresh: False
 

--- a/salt/server/salt.sls
+++ b/salt/server/salt.sls
@@ -1,9 +1,9 @@
 salt_pkgrepo:
   pkgrepo.managed:
     - humanname: SaltStack
-    - name: deb http://repo.saltstack.com/apt/ubuntu/16.04/amd64/2018.3 xenial main 
+    - name: deb https://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2 bionic main
     - file: /etc/apt/sources.list.d/saltstack.list
-    #- key_url: https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2018.3/SALTSTACK-GPG-KEY.pub 
+    #- key_url: https://repo.saltstack.com/apt/ubuntu/18.04/amd64/2019.2/SALTSTACK-GPG-KEY.pub
     - clean_file: True
     - refresh: False
 

--- a/salt/server/tools/map.jinja
+++ b/salt/server/tools/map.jinja
@@ -7,4 +7,16 @@
   },
 },
 grain='id',
-)%}
+) %}
+
+{% set minio = salt['grains.filter_by']({
+  '*-test-*': {
+    'version': 'RELEASE.2017-10-27T18-59-02Z',
+  },
+  '*-prod-*': {
+    'version': 'RELEASE.2017-10-27T18-59-02Z',
+  },
+},
+grain='id',
+) %}
+

--- a/salt/server/tools/minio.config
+++ b/salt/server/tools/minio.config
@@ -1,0 +1,3 @@
+# Local export path.
+MINIO_VOLUMES="/mnt/"
+MINIO_OPTS="--config-dir /etc/minio"

--- a/salt/server/tools/minio.service
+++ b/salt/server/tools/minio.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Minio
+Documentation=https://docs.minio.io
+Wants=network-online.target
+After=network-online.target
+AssertFileIsExecutable=/usr/local/bin/minio
+
+[Service]
+WorkingDirectory=/usr/local/
+
+#User=minio-user
+#Group=minio-user
+
+PermissionsStartOnly=true
+
+EnvironmentFile=-/etc/default/minio
+ExecStartPre=/bin/bash -c "[ -n \"${MINIO_VOLUMES}\" ] || echo \"Variable MINIO_VOLUMES not set in /etc/default/minio\""
+
+ExecStart=/usr/local/bin/minio server $MINIO_OPTS $MINIO_VOLUMES
+
+StandardOutput=journal
+StandardError=inherit
+
+# Specifies the maximum file descriptor number that can be opened by this process
+LimitNOFILE=65536
+
+# Disable timeout logic and wait until process is stopped
+TimeoutStopSec=0
+
+# SIGTERM signal is used to stop Minio
+KillSignal=SIGTERM
+
+SendSIGKILL=no
+
+SuccessExitStatus=0
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/server/tools/minio.sls
+++ b/salt/server/tools/minio.sls
@@ -1,0 +1,28 @@
+{% from "server/tools/map.jinja" import minio with context %}
+
+/usr/local/bin/minio:
+  file.managed:
+    - source: https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.{{ minio.version }}
+    - source_hash: https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.{{ minio.version }}.sha256sum
+    - user: root
+    - group: root
+    - mode: 755
+
+/etc/systemd/system/minio.service:
+  file.managed:
+    - source: salt://server/tools/minio.service
+    - user: root
+    - group: root
+    - mode: 755
+
+/etc/default/minio:
+  file.managed:
+    - source: salt://server/tools/minio.config
+    - user: root
+    - group: root
+    - mode: 644
+    - replace: False
+
+minio:
+  service.running:
+    - enable: True


### PR DESCRIPTION
This minio-server installation should preserve current version *and* config (replace:false). But it is a valid installation set of it self.
The use of 'minio-user' for the process is by-passed, and in line with the current implementation it is all as user 'root'.