### PR TITLE
InfluxDB now managed also in production, and upgraded

### DIFF
--- a/salt/server/influxdb/map.jinja
+++ b/salt/server/influxdb/map.jinja
@@ -1,6 +1,6 @@
 {% set influxdb = salt['grains.filter_by']({
   'server-prod-salt': {
-    'version': '1.4.2',
+    'version': '1.7.4',
   },
   'server-test-api': {
     'version': '1.7.4',

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -21,6 +21,7 @@ base:
     - server/node
 
   server-prod-salt:
+    - server/influxdb
     - server/tools/mc
     - server/grafana
 


### PR DESCRIPTION
InfluxDB Version  1.7.4 is tested on test-api for Grafana/Telegraf. Should be tested for the 'devices' that use it also, before proceeding to production. But we don't have that in test I think.