### PR TITLE
Increase time logs are kept

### DIFF
--- a/salt/pi/rsyslog
+++ b/salt/pi/rsyslog
@@ -12,7 +12,7 @@
 /var/log/debug
 /var/log/messages
 {
-	rotate 4
+	rotate 30
 	weekly
 	missingok
 	notifempty


### PR DESCRIPTION
Increase time logs are kept from 4 to 30 weeks. 