### PR TITLE
Fix whitespace issue for `sunrise-sunset` field

### DIFF
--- a/salt/pi/thermal-recorder/thermal-recorder.yaml.jinja
+++ b/salt/pi/thermal-recorder/thermal-recorder.yaml.jinja
@@ -21,7 +21,7 @@ recorder:
 {%- set win_start, win_end = window.split('-') %}
     window-start: '{{ win_start }}'
     window-end: '{{ win_end }}'
-{%- else -%}
+{%- else %}
     sunrise-sunset: {{ salt['grains.get']('cacophony:recorder-no-window', 'true') }}
     # sunrise-offset: 30
     # sunset-offset: 30


### PR DESCRIPTION
The indentation before the option was being removed.