### PR TITLE
Implement auto update service for Raspberry Pis

### DIFF
--- a/tools/salt-auto-update.py
+++ b/tools/salt-auto-update.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python -u
+
+
+"""Automatically schedule a state.apply for Raspberry Pis when they
+connect to the Salt master.
+
+Updates will not be scheduled for a device if it has already received
+one within MIN_UPDATE_INTERVAL.
+
+A blacklist file exists at MINION_BLACKLIST_PATH to block automatic
+updates for specific devices.
+"""
+
+from __future__ import print_function
+
+from datetime import datetime, timedelta
+from itertools import imap, ifilter
+import re
+import sys
+import time
+
+from dateutil.parser import parse as parse_date
+from influxdb import InfluxDBClient
+import salt.client
+
+from salt_listener import SaltListener
+
+# don't update a device if it was last updated less than this long ago
+MIN_UPDATE_INTERVAL = timedelta(hours=23)
+
+# path to a file listing minions which should never be auto-updated
+MINION_BLACKLIST_PATH = "/etc/salt/autoupdate.blacklist"
+
+# InfluxDB database used to track state
+DB_NAME = "last-updated"
+
+# pattern to match tags for minion start events
+START_EVENT_PATTERN = re.compile("^salt/minion/([^/]+)/start$")
+
+
+def main():
+    print("loading blacklist")
+    blacklist = load_file_lines(MINION_BLACKLIST_PATH)
+
+    print("connecting to InfluxDB")
+    state = UpdateState(DB_NAME, MIN_UPDATE_INTERVAL)
+
+    print("creating Salt client")
+    salt_client = salt.client.LocalClient(auto_reconnect=True)
+
+    # listen to salt-master events, filter out anything other than
+    # minion start events
+    event_matches = imap(match_start_event, iter(SaltListener()))
+    event_matches = ifilter(bool, event_matches)
+
+    # extract out minion_ids, filter out servers
+    minion_ids = imap(lambda m: m.group(1), event_matches)
+    minion_ids = ifilter(not_server, minion_ids)
+
+    # filter out blacklisted minions
+    minion_ids = ifilter(lambda m: not m in blacklist, minion_ids)
+
+    # filter out minions that have already been updated recently
+    minion_ids = ifilter(state.is_update_required, minion_ids)
+
+    print("listening for minion start events")
+    for minion_id in minion_ids:
+        print("scheduling update for", minion_id)
+        jid = salt_client.cmd_async(minion_id, "state.apply")
+        print("  job id", jid)
+        state.record_update(minion_id)
+
+
+def load_file_lines(filename):
+    try:
+        return set(x.strip() for x in open(filename))
+    except IOError:
+        return set()
+
+
+def match_start_event(event):
+    if event is None:
+        return None
+
+    tag = event.get("tag", "")
+    if tag == "salt/event/exit":
+        sys.exit()
+
+    return START_EVENT_PATTERN.match(tag)
+
+
+def not_server(minion_id):
+    return not minion_id.startswith("server-")
+
+
+class UpdateState:
+    def __init__(self, db_name, min_interval):
+        self.influx = InfluxDBClient("localhost", 8086, database=db_name)
+        self.min_interval = min_interval
+
+    def is_update_required(self, minion_id):
+        last_t = self.last_update_time(minion_id)
+        if not last_t:
+            return True  # never auto-updated before
+
+        now = datetime.now(last_t.tzinfo)
+        return (now - last_t) > self.min_interval
+
+    def record_update(self, minion_id):
+        ts = datetime.utcnow()
+        self.influx.write_points(
+            [
+                {
+                    "measurement": "updates",
+                    "time": ts,
+                    "tags": {"device": minion_id},
+                    "fields": {"u": True},  # dummy field required
+                }
+            ]
+        )
+
+    def last_update_time(self, minion_id):
+        results = list(
+            self.influx.query(
+                "select last(*) from updates where device = '{}'".format(minion_id)
+            ).get_points()
+        )
+        if not results:
+            return None
+        return parse_date(results[0]["time"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/salt-auto-update.service
+++ b/tools/salt-auto-update.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Salt minion update scheduler
+After=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/srv/tools/salt-auto-update.py
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/salt-presence.py
+++ b/tools/salt-presence.py
@@ -5,16 +5,17 @@ This tool subscribes to minion events from the Salt master and writes presence
 events to InfluxDB. This is used to drive a Grafana dashboard.
 """
 
+from __future__ import print_function
+
 from datetime import datetime, timedelta
 from influxdb import InfluxDBClient
-from multiprocessing import Process
-import salt.config
-import salt.utils.event
 import sys
 import time
 
+from salt_listener import SaltListener
+
 # How often to check for dead minions to mark as such.
-UPDATE_INTERVAL = timedelta(seconds=30)
+UPDATE_DEAD_INTERVAL = timedelta(seconds=30)
 
 # Minions must ping or re-auth at least this period in order to be considered
 # alive.
@@ -25,33 +26,23 @@ MAX_DOWN_INTERVAL = timedelta(days=10)
 
 
 def main():
-    opts = salt.config.client_config('/etc/salt/master')
-    listener = salt.utils.event.get_event(
-        'master',
-        sock_dir=opts['sock_dir'],
-        transport=opts['transport'],
-        opts=opts)
-
     influx = influx_connect()
 
     # Give extra time on watcher startup for minions to report in to avoid
     # marking minions as down if the watcher has been down for a while.
-    last_update_t = datetime.now() + UPDATE_INTERVAL
+    last_update_t = datetime.now() + UPDATE_DEAD_INTERVAL
 
-    print "listening for events"
+    print("listening for events")
     up_count = 0
-    update_seconds = UPDATE_INTERVAL.total_seconds()
-    timeout_seconds = update_seconds / 2
-    while True:
-        event = listener.get_event(wait=timeout_seconds, full=True)
+    for event in SaltListener(timeout=UPDATE_DEAD_INTERVAL / 2):
         minion_id, ts = process_event(event)
         if minion_id:
-            up_count += 1 
+            up_count += 1
             write_presence(influx, minion_id, True, ts)
 
         now = datetime.now()
-        if now - last_update_t > timedelta(seconds=update_seconds):
-            print "{} up events received".format(up_count)
+        if (now - last_update_t) > UPDATE_DEAD_INTERVAL:
+            print("{} up events received".format(up_count))
             process_down_minions(influx)
             last_update_t = now
 
@@ -60,35 +51,39 @@ def process_event(event):
     if event is None:
         return None, None
 
-    tag = event.get('tag', '')
-    data = event.get('data', {})
+    tag = event.get("tag", "")
+    data = event.get("data", {})
 
-    if tag == 'salt/event/exit':
+    if tag == "salt/event/exit":
         sys.exit()
-    elif tag in ('salt/auth', 'minion_ping'):
-        return data.get('id'), parse_stamp(data.get('_stamp'))
+    elif tag in ("salt/auth", "minion_ping"):
+        return data.get("id"), parse_stamp(data.get("_stamp"))
     return None, None
 
 
 def parse_stamp(s):
     return datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%f")
 
-    
+
 def influx_connect():
-    client = InfluxDBClient('localhost', 8086, database='device-status')
-    client.create_database('device-status')
+    client = InfluxDBClient("localhost", 8086, database="device-status")
+    client.create_database("device-status")
     return client
 
 
 def write_presence(client, minion_id, up, stamp=None):
     if stamp is None:
         stamp = datetime.utcnow()
-    client.write_points([{
-        "measurement": "presence",
-        "time": stamp,
-        "tags": {"device": minion_id},
-        "fields": {"up": up},
-        }])
+    client.write_points(
+        [
+            {
+                "measurement": "presence",
+                "time": stamp,
+                "tags": {"device": minion_id},
+                "fields": {"up": up},
+            }
+        ]
+    )
 
 
 def process_down_minions(client):
@@ -97,23 +92,23 @@ def process_down_minions(client):
     max_down_t = datetime_to_t(now - MAX_DOWN_INTERVAL)
 
     results = client.query(
-        "select device, last(up) as up from presence group by device",
-        epoch='s')
+        "select device, last(up) as up from presence group by device", epoch="s"
+    )
     for r in results.get_points():
         # A "down" event is written event for even for minions which are
         # already marked as down so that Grafana will still see them even when
-	    # displaying a small time range.
-        # 
+        # displaying a small time range.
+        #
         # However, if a minion has been down for over some long time
         # (MAX_DOWN_INTERVAL) then stop writing out down records so that
         # permanently dead minions eventually disappear from the dashboard.
-        if max_down_t < r['time'] < presence_update_t:
-            write_presence(client, r['device'], False)
+        if max_down_t < r["time"] < presence_update_t:
+            write_presence(client, r["device"], False)
 
 
 def datetime_to_t(dt):
     return time.mktime(dt.timetuple())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/salt_listener.py
+++ b/tools/salt_listener.py
@@ -1,0 +1,20 @@
+import salt.config
+import salt.utils.event
+
+ETC_SALT_MASTER = "/etc/salt/master"
+
+
+class SaltListener:
+    def __init__(self, timeout=None):
+        opts = salt.config.client_config(ETC_SALT_MASTER)
+        self.listener = salt.utils.event.get_event(
+            "master", sock_dir=opts["sock_dir"], transport=opts["transport"], opts=opts
+        )
+        if timeout is None:
+            self.timeout_secs = 0
+        else:
+            self.timeout_secs = timeout.total_seconds()
+
+    def __iter__(self):
+        while True:
+            yield self.listener.get_event(wait=self.timeout_secs, full=True)


### PR DESCRIPTION
The new salt-auto-update service automatically schedules a `state.apply` when minions connect to the salt master, unless they've already received an update in the last 23 hrs.

A blacklist file at /etc/salt/autoupdate.blacklist can be used to prevent auto updates of specific devices.

As part of this the logic for listening to the salt-master events was abstracted. The salt-presence services now uses this too (and was cleaned up a little in the process).