### PR TITLE
thermal-recorder 1.18.0 for beta devices

### DIFF
--- a/salt/pi/thermal-recorder/init.sls
+++ b/salt/pi/thermal-recorder/init.sls
@@ -2,7 +2,7 @@ thermal-recorder-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-recorder
     {% if salt['grains.get']('cacophony:recorder-beta') %}
-    - version: "1.17.0"
+    - version: "1.18.0"
     {% else %}
     - version: "1.17.0"
     {% endif %}

--- a/salt/pi/thermal-recorder/thermal-recorder.yaml.jinja
+++ b/salt/pi/thermal-recorder/thermal-recorder.yaml.jinja
@@ -65,7 +65,7 @@ motion:
     edge-pixels: 1
 
     # Verbose gives lots of information on which pixels are detected as changed.
-    verbose: false
+    verbose: {{ salt['grains.get']('cacophony:recorder-motion-debug', 'false') }}
 
 # Throttling of recording (for wind or animal in trap)
 throttler:


### PR DESCRIPTION
With new `cacophony:recorder-motion-debug` grain to enable motion detection debugging feature.