### PR TITLE
Wait for minion_id

### DIFF
--- a/salt/pi/salt-minion/init.sls
+++ b/salt/pi/salt-minion/init.sls
@@ -12,9 +12,7 @@ salt_pkgrepo:
   file.managed:
     - source: salt://pi/salt-minion/minion
 
-wait_for_salt_id:
-  file.line:
-    - name: /lib/systemd/system/salt-minion.service
-    - mode: ensure
-    - after: "After=.+"
-    - content: ConditionPathExists=/etc/salt/minion_id
+/etc/systemd/system/salt-minion.service.d/override.conf:
+   file.managed:
+     - makedirs: True
+     - source: salt://pi/salt-minion/override.conf

--- a/salt/pi/salt-minion/init.sls
+++ b/salt/pi/salt-minion/init.sls
@@ -12,3 +12,9 @@ salt_pkgrepo:
   file.managed:
     - source: salt://pi/salt-minion/minion
 
+wait_for_salt_id:
+  file.line:
+    - name: /lib/systemd/system/salt-minion.service
+    - mode: ensure
+    - after: "After=.+"
+    - content: ConditionPathExists=/etc/salt/minion_id

--- a/salt/pi/salt-minion/override.conf
+++ b/salt/pi/salt-minion/override.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/etc/salt/minion_id


### PR DESCRIPTION
Will prevent salt-minion.service from running if there is no minion_id file.