### PR TITLE
thermal recorder to 1.18.0 and more sensitive motion detection

### DIFF
--- a/salt/pi/thermal-recorder/init.sls
+++ b/salt/pi/thermal-recorder/init.sls
@@ -4,7 +4,7 @@ thermal-recorder-pkg:
     {% if salt['grains.get']('cacophony:recorder-beta') %}
     - version: "1.18.0"
     {% else %}
-    - version: "1.17.0"
+    - version: "1.18.0"
     {% endif %}
 
 # Install support for exFAT & NTFS filesystems (for USB drives)

--- a/salt/pi/thermal-recorder/thermal-recorder.yaml.jinja
+++ b/salt/pi/thermal-recorder/thermal-recorder.yaml.jinja
@@ -29,7 +29,7 @@ recorder:
 motion:
     # Movement below raw temperatures of this value will not activate
     # motion detection.
-    temp-thresh: {{ salt['grains.get']('cacophony:recorder-temp-thresh', 3000) }}
+    temp-thresh: {{ salt['grains.get']('cacophony:recorder-temp-thresh', 2850) }}
 
     # Minimum raw temperature difference between recent frames to
     # trigger motion detection.
@@ -54,7 +54,7 @@ motion:
 
     # No. of sequential frames that must have motion detected before a recording will
     # start.   Having this > 1 helps prevent false positives causing recordings
-    trigger-frames: {{ salt['grains.get']('cacophony:recorder-trigger-frames', 2) }}
+    trigger-frames: {{ salt['grains.get']('cacophony:recorder-trigger-frames', 1) }}
 
     # If set to true, then the frame diff only considers pixels that have become warmer.
     # Otherwise there are ghost pixels where the animal used to be but isn't now.


### PR DESCRIPTION
* Set more sensitve motion detection params. These have been working well on akaroa24 and cam-test-04.
* Roll out thermal-recorder 1.18.0 everywhere 