### PR TITLE
GPIO boot config

### DIFF
--- a/salt/pi/basics.sls
+++ b/salt/pi/basics.sls
@@ -1,6 +1,7 @@
 /boot/config.txt:
    file.managed:
-     - source: salt://pi/config.txt
+     - source: salt://pi/config.txt.jinja
+     - template: jinja
 
 /etc/modules:
    file.managed:

--- a/salt/pi/config.txt
+++ b/salt/pi/config.txt
@@ -21,4 +21,4 @@ dtparam=spi=on
 dtoverlay=hifiberry-dac
 
 # Helps with loading RTC at boot properly
-gpio=22=op,dh
+gpio=23=op,dh

--- a/salt/pi/config.txt.jinja
+++ b/salt/pi/config.txt.jinja
@@ -22,3 +22,11 @@ dtoverlay=hifiberry-dac
 
 # Helps with loading RTC at boot properly
 gpio=23=op,dh
+
+# Default the pin to control the power to the USB plug (data modem) high
+{% set hw_rev = salt['grains.get']('cacophony:hw:rev') | int -%}
+{%- if hw_rev >= 2 -%}
+gpio=22=op,dh
+{% else %}
+gpio=18=op,dh
+{%- endif %}


### PR DESCRIPTION
- fix pin for thermal camera, helping the RTC load properly
- Have USB power on by default (will help when loading the USB modem)

When the pins are not set at boot they can be odd voltages (0.9V). This can cause transistors that are connected to them to be "half on" causing weird behavior if the transistors power devices (thermal camera, modems)
 