### PR TITLE
Lower the i2c speed to 50kH to prevent errors when talking to the attiny

### DIFF
--- a/pi/config.txt.jinja
+++ b/pi/config.txt.jinja
@@ -15,7 +15,7 @@ gpu_freq=200
 gpu_freq_min=200
 {%- endif %}
 
-dtparam=i2c_arm=on
+dtparam=i2c_arm=on,i2c_arm_baudrate=50000
 dtoverlay=i2c-rtc,pcf8523
 dtparam=spi=on
 


### PR DESCRIPTION
- Lowered to 50kH from the default 100kH. 
- Lepton camera and RTC look to still work at this speed