### PR TITLE
Removed now-unused thermal-recorder watches

### DIFF
--- a/pi/thermal-recorder/init.sls
+++ b/pi/thermal-recorder/init.sls
@@ -24,7 +24,6 @@ thermal-recorder-service:
     - enable: True
     - watch:
       - thermal-recorder-pkg
-      - /etc/thermal-recorder.yaml
 
 leptond-service:
   service.running:
@@ -32,7 +31,6 @@ leptond-service:
     - enable: True
     - watch:
       - thermal-recorder-pkg
-      - /etc/leptond.yaml
 
 set-thermal-recorder-output:
   service.enabled: []


### PR DESCRIPTION
## Description

Removed now-unused thermal-recorder watches.

## Testing

Tested on pi with `salt-call --local state.apply pi/thermal-recorder`

## top.sls changes

Not relevant.