### PR TITLE
Repair salt-minion keys if required

### DIFF
--- a/pi/salt-minion/check-salt-keys
+++ b/pi/salt-minion/check-salt-keys
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+pki_dir=/etc/salt/pki/minion/
+minion_pub_key=$pki_dir/minion.pub
+minion_priv_key=$pki_dir/minion.pem
+
+restart=no
+while getopts ":r" opt; do
+  case ${opt} in
+    r) 
+      restart=yes
+      ;;
+    \?) 
+      echo -e "Usage: $0  [ -r ]\n\n    -r: restart salt-minion if keys cleared"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -f $minion_pub_key ]] && [[ ! -s $minion_pub_key ]]; then
+   echo "salt-minion public key file is empty - deleting keys"
+   rm -f $minion_pub_key
+   rm -f $minion_priv_key
+   if [[ $restart == yes ]]; then
+     echo "restarting salt-minion"
+     systemctl restart salt-minion
+   fi
+fi

--- a/pi/salt-minion/check-salt-keys.cron
+++ b/pi/salt-minion/check-salt-keys.cron
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/local/bin/check-salt-keys -r 2>&1 | logger --tag check-salt-keys

--- a/pi/salt-minion/init.sls
+++ b/pi/salt-minion/init.sls
@@ -3,7 +3,6 @@ salt_pkgrepo:
     - humanname: SaltStack
     - name: deb http://repo.saltstack.com/apt/debian/9/armhf/2018.3 stretch main
     - file: /etc/apt/sources.list.d/saltstack.list
-    #- key_url: https://repo.saltstack.com/apt/debian/9/armhf/2018.3/SALTSTACK-GPG-KEY.pub
     - clean_file: True
     - refresh: False
 
@@ -16,3 +15,13 @@ salt_pkgrepo:
    file.managed:
      - makedirs: True
      - source: salt://pi/salt-minion/override.conf
+
+/usr/local/bin/check-salt-keys:
+  file.managed:
+    - source: salt://pi/salt-minion/check-salt-keys
+    - mode: 755
+
+/etc/cron.hourly/check-salt-keys:
+  file.managed:
+    - source: salt://pi/salt-minion/check-salt-keys.cron
+    - mode: 755

--- a/pi/salt-minion/override.conf
+++ b/pi/salt-minion/override.conf
@@ -1,2 +1,5 @@
 [Unit]
 ConditionPathExists=/etc/salt/minion_id
+
+[Service]
+ExecStartPre=/usr/local/bin/check-salt-keys


### PR DESCRIPTION
## Description

Added new check-salt-keys helper which will delete the salt minion's key files if they are empty.

This is called every hour as well as just before the salt-minion starts. The salt-minion will be restarted by the hourly check if a problem is found.

See https://trello.com/c/flexPujq/639-if-salt-minion-key-files-are-empty-delete-and-restart-minion

## Testing

Developed and tested on a pi with `salt-call --local`

## top.sls changes

N.A.