### PR TITLE
Increase the salt minion log level to info

### DIFF
--- a/pi/salt-minion/minion
+++ b/pi/salt-minion/minion
@@ -50,3 +50,5 @@ tcp_keepalive_cnt: 3
 # use OS defaults, typically 75 seconds on Linux, see
 # /proc/sys/net/ipv4/tcp_keepalive_intvl.
 tcp_keepalive_intvl: 20
+
+log_level: info


### PR DESCRIPTION
This supports troubleshooting for failed upgrades and salt issues generally.

## Testing

Developed and tested on pi. Ran salt command from master to confirm relevant logs are being generated.

## top.sls changes

N.A.
