### PR TITLE
Don't reboot immediately when required

### DIFF
--- a/pi/maybe-reboot.sls
+++ b/pi/maybe-reboot.sls
@@ -1,6 +1,7 @@
 reboot_after_boot_changes:
   module.run:
     - name: system.reboot
+    - at_time: 1
     - onchanges:
       - /boot/config.txt
       - /boot/cmdline.txt
@@ -9,4 +10,5 @@ reboot_after_boot_changes:
 reboot_for_config_import:
   module.run:
     - name: system.reboot
+    - at_time: 1
     - unless: test -f /etc/cacophony/config.toml


### PR DESCRIPTION
## Description

If a reboot is required after an update completes, delay it by a minute.
This means the salt master gets to see the result of the state.apply
instead of it looking that the command never completed.

## Testing

Tested on pi using `salt-call --local`

## top.sls changes

N.A.