### PR TITLE
Minion logging tweaks

### DIFF
--- a/pi/salt-minion/minion
+++ b/pi/salt-minion/minion
@@ -51,4 +51,10 @@ tcp_keepalive_cnt: 3
 # /proc/sys/net/ipv4/tcp_keepalive_intvl.
 tcp_keepalive_intvl: 20
 
-log_level: info
+log_level: warning      # console
+log_level_logfile: info # log file
+
+# Turn off log spam for scheduled jobs
+log_granular_levels:
+  salt: info
+  salt.utils.schedule: warning


### PR DESCRIPTION
## Description

- Turn down console log level to avoid doubled up logging
- Turn off scheduler logs to avoid uninteresting log spam

## Testing

Tested on a dev pi. Ran salt jobs to confirm desired output.

## top.sls changes

N.A.
