### PR TITLE
Bump go-config to 1.2.0

### DIFF
--- a/pi/config/init.sls
+++ b/pi/config/init.sls
@@ -1,5 +1,5 @@
 cacophony-config-pkg:
   cacophony.pkg_installed_from_github:
     - name: go-config
-    - version: "1.1.1"
+    - version: "1.2.0"
     - pkg_name: cacophony-config


### PR DESCRIPTION
## Description

Pull in battery defaults changes.

## Testing

Visual only.

## top.sls changes

N.A.