### PR TITLE
Add stay on requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,5 @@ Briefly describe how the change was tested.
 ## top.sls changes
 
 - [ ] Does this change require an update to top.sls in the `master` branch?
-- [ ] Has the relevant PR for the top.sls been prepared
-
+- [ ] Has the relevant PR for the top.sls (including local `salt/top.sls`) been prepared
 Please include a references to any related PRs.

--- a/pi/end/init.sls
+++ b/pi/end/init.sls
@@ -1,0 +1,2 @@
+'systemctl stop stay-on':
+  cmd.run

--- a/pi/start/init.sls
+++ b/pi/start/init.sls
@@ -1,0 +1,19 @@
+/usr/bin/stay-on:
+  file.managed:
+    - source: salt://pi/start/stay-on
+    - mode: 755
+
+stay-on-service-file:
+  file.managed:
+    - name: /etc/systemd/system/stay-on.service
+    - source: salt://pi/start/stay-on.service
+    - mode: 644
+
+stay-on-service-reload:
+  cmd.wait:
+    - name: "systemctl daemon-reload"
+    - watch:
+      - stay-on-service-file
+
+'systemctl restart stay-on':
+  cmd.run

--- a/pi/start/stay-on
+++ b/pi/start/stay-on
@@ -1,0 +1,9 @@
+#!/bin/bash
+for i in {1..30}
+do
+  echo "stay on request"
+  dbus-send --system --type=method_call --print-reply --dest=org.cacophony.ATtiny /org/cacophony/ATtiny org.cacophony.ATtiny.StayOnFor int64:1
+  dbus-send --system --type=method_call --print-reply --dest=org.cacophony.modemd /org/cacophony/modemd org.cacophony.modemd.StayOn
+  sleep 50s
+done
+echo "stay on requests stopped from timeout"

--- a/pi/start/stay-on.service
+++ b/pi/start/stay-on.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run script to send stay-on requests to modemd and attiny`
+
+[Service]
+ExecStart=/usr/bin/stay-on
+
+[Install]
+WantedBy=basic.target

--- a/salt/.gitignore
+++ b/salt/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!top.sls

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -20,5 +20,5 @@ base:
     - pi/device-register
     - pi/energy-savings
     - pi/removed
-    - pi/end
     - pi/maybe-reboot
+    - pi/end

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,0 +1,24 @@
+base:
+  '*':
+    - pi/start
+    - timezone
+    - pi/config
+    - pi/basics
+    - pi/auth
+    - pi/salt-minion
+    - pi/wpa
+    - pi/rtc
+    - pi/watchdog
+    - pi/modemd
+    - pi/attiny-controller
+    - pi/audio
+    - pi/event-reporter
+    - pi/audiobait
+    - pi/thermal-recorder
+    - pi/thermal-uploader
+    - pi/management-interface
+    - pi/device-register
+    - pi/energy-savings
+    - pi/removed
+    - pi/end
+    - pi/maybe-reboot

--- a/state-apply-test.sh
+++ b/state-apply-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+
+
+device=$1
+params=$2
+
+if [[ -z $device ]]; then
+  echo "please provide device name"
+  exit 1
+fi
+
+# copy files to local folder
+cp -r basics.sls _modules/ pi/ _states/ timezone.sls salt/
+
+ssh pi@$device "sudo rm -rf salt /srv/salt"
+
+# copy onto device
+echo "copying files to device.."
+scp -rq salt pi@$device:
+echo "done"
+
+echo "moving files to /srv"
+ssh pi@$device "sudo cp -r salt /srv/"
+echo "done"
+
+cmd="ssh pi@$device \"sudo salt-call --local state.apply $params --state-output=mixed\""
+echo "running $cmd"
+eval $cmd

--- a/state-apply-test.sh
+++ b/state-apply-test.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-
-
+# This is to help testing salt changes on a Raspberry Pi
+# Usage: state-apply-test.sh [devicename] [state.apply params]
+# If you need to make changes to top.sls make the changes in `salt/top.sls` This is what is used when testing
 
 device=$1
 params=$2
 
 if [[ -z $device ]]; then
-  echo "please provide device name"
+  echo "please provide device name. Usage \`state-apply-test.sh [devicename] [state.apply params]\`"
   exit 1
 fi
 


### PR DESCRIPTION
## Description

When running a salt state.apply "stay-on" requests will go to `attiny-controller` and `modemd` to keep the device on and internet up while the device is updating
- Added `state-apply-test.sh` This can be used to help with testing salt changes on a device.

## Testing

Tested on my device

## top.sls changes
https://github.com/TheCacophonyProject/saltops/pull/154