### PR TITLE
Keep libopenal - it's required by ffmpeg

### DIFF
--- a/server/basics.sls
+++ b/server/basics.sls
@@ -31,7 +31,6 @@ unused.packages:
       - fonts-droid-fallback
       - ghostscript
       - libcups2
-      - libopenal-data
       - ntfs-3g
       - manpages-dev
       - ruby


### PR DESCRIPTION
## Description

libopenal is required by ffmpeg.

## Testing

Manually tested on server-test-processing

## top.sls changes

N.A.