### PR TITLE
Manage fake-hwclock service file

### DIFF
--- a/pi/rtc/fake-hwclock.service
+++ b/pi/rtc/fake-hwclock.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Restore / save the current clock
+Documentation=man:fake-hwclock(8)
+DefaultDependencies=no
+Before=sysinit.target systemd-fsck-root.service
+Conflicts=shutdown.target
+
+[Service]
+EnvironmentFile=-/etc/default/fake-hwclock
+ExecStart=/sbin/fake-hwclock load $FORCE
+ExecStop=/sbin/fake-hwclock save
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/pi/rtc/init.sls
+++ b/pi/rtc/init.sls
@@ -1,25 +1,8 @@
-# Start fake-hwclock after /dev is loaded
-start_fake_hwclock_after_sysinit:
-  file.line:
-    - name: /lib/systemd/system/fake-hwclock.service
-    - mode: ensure
-    - after: "DefaultDependencies=.+"
-    - content: "After=sysinit.target"
-
-# Start fake-hwclock before general startup
-start_fake_hwclock_before_basic:
-  file.replace:
-    - name: /lib/systemd/system/fake-hwclock.service
-    - pattern: "^Before=.+"
-    - repl: "Before=basic.target"
-
-dont_start_fake_hwclock_if_rtc_exists:
-  file.line:
-    - name: /lib/systemd/system/fake-hwclock.service
-    - mode: ensure
-    - after: "Conflicts=.+"
-    - content: "ConditionPathExists=!/dev/rtc0"
-
+# Manage fake-hwclock service file.
+/lib/systemd/system/fake-hwclock.service:
+  file.managed:
+    - source: salt://pi/rtc/fake-hwclock.service
+    - mode: 644
 
 rtc-utils-pkg:
   cacophony.pkg_installed_from_github:


### PR DESCRIPTION
## Description

Manage the fake-hwclock service file to what it is by default.
Previously we didn't want the fake-hwclock running in parallel to the RTC software as we were worried with it conflicting but fake-hwclock will only update the system time forward and not backwards. This means it shouldn't conflict with the RTC software we have running.

## Testing

Tested the clock on my device in multiple conditions, no RTC, no internet, no internet or RTC.

## top.sls changes
NA
