### PR TITLE
Write to disk more often to reduce data loss

### DIFF
--- a/pi/97-cacophony.conf
+++ b/pi/97-cacophony.conf
@@ -1,0 +1,3 @@
+# Write data to disk more often to reduce logs/data lost when power is cut
+vm.dirty_writeback_centisecs = 300
+vm.dirty_expire_centisecs = 300

--- a/pi/basics.sls
+++ b/pi/basics.sls
@@ -29,3 +29,8 @@ default-hw-rev:
     - name: cacophony:hw:rev
     - value: 2
 {% endif %}
+
+/etc/sysctl.d/97-cacophony.conf:
+  file.managed:
+    - source: salt://pi/97-cacophony.conf
+    -  mode: 644


### PR DESCRIPTION
## Description

Will write data to disk more often (sync) to reduce the logs lost when power is lost.

## Testing

Tested on my device by pulling the power when looking at the logs (/var/log/syslog) over ssh.
With the default settings I tested it three times and lost 8s, 12s, 19s of logs.
With the new settings I lost 5s, 2s, 2s of logs.

No noticeable power change with the new settings.

## top.sls changes
NA