### PR TITLE
Add feverscreen pkgrepo

### DIFF
--- a/pi/feverscreen/init.sls
+++ b/pi/feverscreen/init.sls
@@ -1,18 +1,45 @@
-feverscreen-pkg:
-  fever.pkg_installed_from_github:
-    - name: feverscreen
-    - version: "0.5.3"
+{% set beta = salt['grains.fetch']('fs-beta', default=False) %}
+
+feverscreen-pkgrepo:
+  pkgrepo.managed:
+    - humanname: feverscreen
+    {% if beta %}
+    - name: deb [trusted=yes] https://github.com/feverscreen/channel-beta/releases/download/feverscreen ./
+    - key_url: https://github.com/feverscreen/channel-beta/releases/download/feverscreen/default.pub.key
+    {% else %}
+    - name: deb [trusted=yes] https://github.com/feverscreen/channel-stable/releases/download/feverscreen ./
+    - key_url: https://github.com/feverscreen/channel-stable/releases/download/feverscreen/default.pub.key
+    {% endif %}
+    - file: /etc/apt/sources.list.d/feverscreen.list
+    - clean_file: True
+    - refresh: False
+
+feverscreen-packages:
+  pkg.installed:
+    - pkgs:
+      - feverscreen
+    - watch:
+      - feverscreen-pkgrepo
 
 feverscreen-service:
   service.running:
     - name: feverscreen
     - enable: True
     - watch:
-      - feverscreen-pkg
+      - feverscreen-packages
 
 leptond-service:
   service.running:
     - name: leptond
     - enable: True
     - watch:
-      - feverscreen-pkg
+      - feverscreen-packages
+
+/etc/cron.d/update-feverscren:
+  file.managed:
+    {% if beta %}
+    - source: salt://pi/feverscreen/update-feverscreen-beta
+    {% else %}
+    -  source: salt://pi/feverscreen/update-feverscreen
+    {% endif %}
+    - mode: 644

--- a/pi/feverscreen/update-feverscreen
+++ b/pi/feverscreen/update-feverscreen
@@ -1,2 +1,2 @@
 # Update feverscreen every day at 10am
-0 10 * * * root apt-get update; apt-get -y --only-upgrade install feverscreen
+0 10 * * * root sudo apt-get update; sudo apt-get -y --only-upgrade install feverscreen

--- a/pi/feverscreen/update-feverscreen
+++ b/pi/feverscreen/update-feverscreen
@@ -1,0 +1,2 @@
+# Update feverscreen every day at 10am
+0 10 * * * root apt-get update; apt-get -y --only-upgrade install feverscreen

--- a/pi/feverscreen/update-feverscreen-beta
+++ b/pi/feverscreen/update-feverscreen-beta
@@ -1,0 +1,2 @@
+# Update feverscreen every hour
+0 * * * * root apt-get update; apt-get -y --only-upgrade install feverscreen

--- a/pi/feverscreen/update-feverscreen-beta
+++ b/pi/feverscreen/update-feverscreen-beta
@@ -1,2 +1,2 @@
 # Update feverscreen every hour
-0 * * * * root apt-get update; apt-get -y --only-upgrade install feverscreen
+0 * * * * root sudo apt-get update; sudo apt-get -y --only-upgrade install feverscreen


### PR DESCRIPTION
## Description

Add feverscreen package repo.
To add a device to the beta channel set the salt grain `fs-beta` to `true` by running `sudo salt-call  grains.append fs-beta true` on the device or from the salt server `sudo salt [deice-salt-id] grains.append fs-beta true`
To remove from the beta channel run `sudo salt-call  grains.delkey fs-beta` on the device or `sudo salt [deice-salt-id] grains.delkey fs-beta` from the salt server.
Note that the changes won't be applied until a salt update has run on the device.

## Testing

Tested on my device but more testing is needed when we have to different releases on beta and main.

## top.sls changes
NA
