### PR TITLE
Update thermal recorder

### DIFF
--- a/pi/thermal-recorder/init.sls
+++ b/pi/thermal-recorder/init.sls
@@ -1,7 +1,7 @@
 thermal-recorder-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-recorder
-    - version: "2.9.1"
+    - version: "2.9.2"
 
 # Install support for exFAT & NTFS filesystems (for USB drives)
 extra-filesystems:


### PR DESCRIPTION
## Description

On camera errors where the connection wasn't reset, leptond would resent the camera header info while thermal-recorder was expecting a frame.
