### PR TITLE
Add version reporter

### DIFF
--- a/pi/end/init.sls
+++ b/pi/end/init.sls
@@ -1,5 +1,8 @@
 'date --iso-8601=seconds > /etc/cacophony/last-salt-update':
   cmd.run
 
+'version-reporter':
+  cmd.run
+
 'systemctl stop stay-on':
   cmd.run

--- a/pi/event-reporter.sls
+++ b/pi/event-reporter.sls
@@ -1,7 +1,7 @@
 event-reporter-pkg:
   cacophony.pkg_installed_from_github:
     - name: event-reporter
-    - version: "3.1.0"
+    - version: "3.2.0"
 
 event-reporter-service:
   service.running:

--- a/pi/modemd/init.sls
+++ b/pi/modemd/init.sls
@@ -21,7 +21,7 @@
 modemd-pkg:
   cacophony.pkg_installed_from_github:
     - name: modemd
-    - version: "1.1.1"
+    - version: "1.2.2"
 
 modemd:
   service.running:


### PR DESCRIPTION
## Description

- Update modemd to 1.2.2 This will change the default config letting the modem turn of when not used saving energy
- Update event reporter to 3.2.0 adding `version-reporter` that when run will send an event of the software that is install on the device. Gets automatically run on boot.
- Run `version-reporter` at end of salt update
## Testing

Tested on my device

## top.sls changes
NA