### PR TITLE
Fix bug with adding wpa settings multiple times. Added Bushnet wifi settings.

### DIFF
--- a/pi/wpa.sls
+++ b/pi/wpa.sls
@@ -7,10 +7,22 @@ set_wifi_country:
 ensure_bushnet_ssid:
   file.replace:
     - name: /etc/wpa_supplicant/wpa_supplicant.conf
-    - pattern: 'network={\n*\s*ssid="bushnet"\n*\s*psk="feathers"\n*\s*}'
+    - pattern: 'network={\n*\s*ssid="bushnet"\n*\s*psk="feathers"\n*\s*priority=2\n*\s*}'
     - repl: |
         network={
             ssid="bushnet"
+            psk="feathers"
+            priority=2
+        }
+    - append_if_not_found: true
+
+ensure_bushnet_ssid_with_cap:
+  file.replace:
+    - name: /etc/wpa_supplicant/wpa_supplicant.conf
+    - pattern: 'network={\n*\s*ssid="Bushnet"\n*\s*psk="feathers"\n*\s*priority=2\n*\s*}'
+    - repl: |
+        network={
+            ssid="Bushnet"
             psk="feathers"
             priority=2
         }


### PR DESCRIPTION
## Description

- Fix bug where wpa settings for bushnet would get added multiple times
- Added wpa settings for `Bushnet` as lots of phone will capitalize the first letter of there hotspot 
## Testing
Tested on mu device

## top.sls changes
NA