### PR TITLE
updae thermal recorder

### DIFF
--- a/pi/thermal-recorder/init.sls
+++ b/pi/thermal-recorder/init.sls
@@ -1,7 +1,7 @@
 thermal-recorder-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-recorder
-    - version: "2.10.1"
+    - version: "2.10.2"
 
 # Install support for exFAT & NTFS filesystems (for USB drives)
 extra-filesystems:


### PR DESCRIPTION
## Description

Thermal recorder background frame was including the edge pixels.This was causing processed to videos to have bad normalisation 

## Testing

Tested on my pi locally and uploaded recordings to browse-test where they processed properly
