### PR TITLE
Show what nodegroup was used in update

### DIFF
--- a/pi/dev-pis/init.sls
+++ b/pi/dev-pis/init.sls
@@ -1,0 +1,2 @@
+'echo dev-pis > /etc/cacophony/salt-nodegroup':
+  cmd.run

--- a/pi/prod-pis/init.sls
+++ b/pi/prod-pis/init.sls
@@ -1,0 +1,2 @@
+'echo prod-pis > /etc/cacophony/salt-nodegroup':
+  cmd.run

--- a/pi/test-pis/init.sls
+++ b/pi/test-pis/init.sls
@@ -1,2 +1,2 @@
-'echo test-pis > /etc/cacophony/salt-':
+'echo test-pis > /etc/cacophony/salt-nodegroup':
   cmd.run

--- a/pi/test-pis/init.sls
+++ b/pi/test-pis/init.sls
@@ -1,0 +1,2 @@
+'echo test-pis > /etc/cacophony/salt-':
+  cmd.run

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -21,5 +21,6 @@ base:
     - pi/device-register
     - pi/energy-savings
     - pi/removed
+    - pi/dev-pis
     - pi/maybe-reboot
     - pi/end


### PR DESCRIPTION
## Description

Show what nodegroup was used by writing it to file.

## Testing

Tested on my device

## top.sls changes

- [x] Does this change require an update to top.sls in the `master` branch?
- [x] Has the relevant PR for the top.sls (including local `salt/top.sls`) been prepared
Please include a references to any related PRs. https://github.com/TheCacophonyProject/saltops/pull/236
