### PR TITLE
update thermal recorder

### DIFF
--- a/pi/thermal-recorder/init.sls
+++ b/pi/thermal-recorder/init.sls
@@ -1,7 +1,7 @@
 thermal-recorder-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-recorder
-    - version: "2.10.2"
+    - version: "2.11.0"
 
 # Install support for exFAT & NTFS filesystems (for USB drives)
 extra-filesystems:


### PR DESCRIPTION
## Description

Fixes a problem with motion being detected after a camera power cycle from zero pixel event

## Testing

Tested on gp's pi, that after a zero pixel event motion isn't detected and that recordings still record normally

## top.sls changes

- [ ] Does this change require an update to top.sls in the `master` branch?
- [ ] Has the relevant PR for the top.sls (including local `salt/top.sls`) been prepared
Please include a references to any related PRs.
