### PR TITLE
Fix errors when using python3

### DIFF
--- a/_states/cacophony.py
+++ b/_states/cacophony.py
@@ -16,7 +16,7 @@ def pkg_installed_from_github(name, version, pkg_name=None, systemd_reload=True)
     """
 
     # Guard against versions being converted to floats in YAML parsing.
-    assert isinstance(version, basestring), "version must be a string"
+    assert isinstance(version, str), "version must be a string"
 
     if pkg_name == None:
         pkg_name = name
@@ -89,7 +89,7 @@ def init_alsa(name):
 
 def _is_audio_setup():
     output = subprocess.check_output("amixer")
-    return "Simple mixer control 'PCM',0" in output
+    return b"Simple mixer control 'PCM',0" in output
 
 
 def _remove_if_present(name):


### PR DESCRIPTION
## Description

When using the latest version of salt with python3 this causes some of the python code to error.
The changes makes it work with both python3 and 2
## Testing
Tested on my device
## top.sls changes
NA