### PR TITLE
Updated packges so events are created on rename

### DIFF
--- a/pi/device-register.sls
+++ b/pi/device-register.sls
@@ -1,7 +1,7 @@
 device-register-pkg:
   cacophony.pkg_installed_from_github:
     - name: device-register
-    - version: "1.4.0"
+    - version: "1.4.1"
 
 device-register-service:
   service.enabled:

--- a/pi/event-reporter.sls
+++ b/pi/event-reporter.sls
@@ -1,7 +1,7 @@
 event-reporter-pkg:
   cacophony.pkg_installed_from_github:
     - name: event-reporter
-    - version: "3.3.0"
+    - version: "3.3.1"
 
 event-reporter-service:
   service.running:

--- a/pi/management-interface/init.sls
+++ b/pi/management-interface/init.sls
@@ -1,7 +1,7 @@
 management-interface-pkg:
   cacophony.pkg_installed_from_github:
     - name: management-interface
-    - version: "1.11.2"
+    - version: "1.11.3"
 
 managementd-service:
   service.running:


### PR DESCRIPTION
## Description

- Management-interface updated to 1.11.3
- event-reporter updated to 3.3.1
- device-register updated to 1.4.1
- These updates are so config events are created when a device registers or re-registers.
## Testing

Tested on my device
## top.sls changes
NA
