### PR TITLE
update thermal rec, attiny and management

### DIFF
--- a/pi/attiny-controller/init.sls
+++ b/pi/attiny-controller/init.sls
@@ -1,7 +1,7 @@
 attiny-controller-pkg:
   cacophony.pkg_installed_from_github:
     - name: attiny-controller
-    - version: "3.5.0"
+    - version: "3.6.0"
 
 attiny-controller-service:
   service.running:

--- a/pi/management-interface/init.sls
+++ b/pi/management-interface/init.sls
@@ -1,7 +1,7 @@
 management-interface-pkg:
   cacophony.pkg_installed_from_github:
     - name: management-interface
-    - version: "1.11.3"
+    - version: "1.11.4"
 
 managementd-service:
   service.running:

--- a/pi/thermal-recorder/init.sls
+++ b/pi/thermal-recorder/init.sls
@@ -1,7 +1,7 @@
 thermal-recorder-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-recorder
-    - version: "2.15.0"
+    - version: "2.15.1"
 
 # Install support for exFAT & NTFS filesystems (for USB drives)
 extra-filesystems:


### PR DESCRIPTION
## Description

Attiny controller will now send heart beat events
Management interface will send camera preview over web socket, and thermal recorder will send frames over dbus to management interface rather than writing to a file.
## Testing

Briefly describe how the change was tested.

## top.sls changes

- [ ] Does this change require an update to top.sls in the `master` branch?
- [ ] Has the relevant PR for the top.sls (including local `salt/top.sls`) been prepared
Please include a references to any related PRs.
