### PR TITLE
apt-ipdates - force non-interactive (retain old)

### DIFF
--- a/pi/apt-updater/apt-updater-script
+++ b/pi/apt-updater/apt-updater-script
@@ -46,12 +46,12 @@ done
 if [[ $rc -eq 0 ]] ; then                # Did ping succeed in end
     logger apt-updater: Updating now
     #call apt-get update and capture stderr
-    errors=`apt-get update -o Dir::Etc::SourceList=/etc/apt/apt-updater-sources.list -o Dir::Etc::SourceParts=/etc/apt/apt-updater-sources.list.d  2>&1 > /dev/null`
+    errors=`export DEBIAN_FRONTEND=noninteractive; export DEBIAN_PRIORITY=critical; apt-get -qy update -o Dir::Etc::SourceList=/etc/apt/apt-updater-sources.list -o Dir::Etc::SourceParts=/etc/apt/apt-updater-sources.list.d  2>&1 > /var/log/apt_last_update.log`
     check_for_errors $? "apt-get update" "${errors}" 
 
     logger apt-updater: Upgrading now
     #call apt-get upgrade and capture stderr
-    errors=`apt-get upgrade -y -o Dir::Etc::SourceList=/etc/apt/apt-updater-sources.list -o Dir::Etc::SourceParts=/etc/apt/apt-updater-sources.list.d 2>&1 > /dev/null`
+    errors=`export DEBIAN_FRONTEND=noninteractive; export DEBIAN_PRIORITY=critical; apt-get upgrade -qy -o Dir::Etc::SourceList=/etc/apt/apt-updater-sources.list -o Dir::Etc::SourceParts=/etc/apt/apt-updater-sources.list.d -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" 2>&1 >> /var/log/apt_last_update.log`
     check_for_errors $? "apt-get upgrade" "${errors}" 
 
     logger apt-updater: Update complete


### PR DESCRIPTION
## Description

Add parameters to apt-get upgrade to run 'non-interactive, keep old config' where config clashes are detected during upgrade.

## Testing

Pass and fail upgrade scenarios tested on stretch and bullseye RPis.


## top.sls changes

- [No ] Does this change require an update to top.sls in the `master` branch?
- [ ] Has the relevant PR for the top.sls (including local `salt/top.sls`) been prepared
Please include a references to any related PRs.
