### PR TITLE
Fixes version string bug

### DIFF
--- a/_states/cacophony.py
+++ b/_states/cacophony.py
@@ -15,6 +15,7 @@ def pkg_installed_from_github(name, version, pkg_name=None, systemd_reload=True)
     systemd.
     """
 
+    version = version.encode("ascii", 'ignore') # Convert if unicode string to str.
     # Guard against versions being converted to floats in YAML parsing.
     assert isinstance(version, str), "version must be a string"
 


### PR DESCRIPTION
## Description
Version was of type unicode instead of string causing the assertion of type string to fail.
## Testing

Tested using `state-apply-test-rpi.sh` on a device that had this bug.

## top.sls changes
NA
