### PR TITLE
Update cacophony.py

### DIFF
--- a/_states/cacophony.py
+++ b/_states/cacophony.py
@@ -16,6 +16,10 @@ def pkg_installed_from_github(name, version, pkg_name=None, systemd_reload=True)
     """
 
     version = version.encode("ascii", 'ignore') # Convert if unicode string to str.
+    
+    if isinstance(version, bytes): # Convert if byte_encoded (needed for piOS64)
+      version = version.decode('utf-8', 'ignore')
+    
     # Guard against versions being converted to floats in YAML parsing.
     assert isinstance(version, str), "version must be a string"
 


### PR DESCRIPTION
## Description
salt-call state.apply is currently failing in piOS64.
piOS64 returns (some) version strings as byte_encoded_string types
These require conversion to 'str' type in cacophony.py for the apply script to succeed

## Testing
Tested on piOS64 - fixes issue
Tested on stretch - no issues seen

(Test: salt-call --local state.apply)

## top.sls changes

- [ No ] Does this change require an update to top.sls in the `master` branch?
- [ ] Has the relevant PR for the top.sls (including local `salt/top.sls`) been prepared
Please include a references to any related PRs.
