### PR TITLE
Update cacophony.py

### DIFF
--- a/_states/cacophony.py
+++ b/_states/cacophony.py
@@ -15,11 +15,12 @@ def pkg_installed_from_github(name, version, pkg_name=None, systemd_reload=True)
     systemd.
     """
 
-    version = version.encode("ascii", 'ignore') # Convert if unicode string to str.
-    
     if isinstance(version, bytes): # Convert if byte_encoded (needed for piOS64)
       version = version.decode('utf-8', 'ignore')
     
+    if not isinstance(version, str): # Convert if unicode string to str.
+      version = version.encode("ascii", 'ignore') 
+     
     # Guard against versions being converted to floats in YAML parsing.
     assert isinstance(version, str), "version must be a string"
 


### PR DESCRIPTION
## Description

Stretch and piOS64 react differently to unicode and byte string encoding
Handle conversion from byte to unicode in piOS64
Handle conversion from unicode to str in stretch  

## Testing
salt-call --local state.apply in both OS's succeeds


## top.sls changes

- [ No ] Does this change require an update to top.sls in the `master` branch?
- [ ] Has the relevant PR for the top.sls (including local `salt/top.sls`) been prepared
Please include a references to any related PRs.
