### PR TITLE
removed 'servers/salt' from the test

### DIFF
--- a/top.sls
+++ b/top.sls
@@ -37,7 +37,6 @@ test:
     - salt-migration
     - server/basics
     - server/unattended-upgrades
-    - server/salt
     - server/users
     - server/sshd
     - server/telegraf


### PR DESCRIPTION
## Description
Removed `servers/salt` from test
Relevant PR: https://github.com/TheCacophonyProject/saltops/pull/318
