### PR TITLE
Removed sysconfig that made more frequent SD card writes

### DIFF
--- a/pi/97-cacophony.conf
+++ b/pi/97-cacophony.conf
@@ -1,3 +1,0 @@
-# Write data to disk more often to reduce logs/data lost when power is cut
-vm.dirty_writeback_centisecs = 300
-vm.dirty_expire_centisecs = 300

--- a/pi/basics.sls
+++ b/pi/basics.sls
@@ -31,6 +31,4 @@ default-hw-rev:
 {% endif %}
 
 /etc/sysctl.d/97-cacophony.conf:
-  file.managed:
-    - source: salt://pi/97-cacophony.conf
-    -  mode: 644
+  file.absent: []


### PR DESCRIPTION
## Description
Removed old config that caused more frequent SD card writes. Removing this will hopefully cause fewer SD cards to go corrupt.

## Testing

Tested on my device

## top.sls changes
NA