### PR TITLE
update cacophony-config to 1.20.9

### DIFF
--- a/tc2/config/init.sls
+++ b/tc2/config/init.sls
@@ -4,7 +4,7 @@
 cacophony-config-pkg:
   cacophony.pkg_installed_from_github:
     - name: go-config
-    - version: "1.20.4"
+    - version: "1.20.9"
     - pkg_name: cacophony-config
     - branch: master
 


### PR DESCRIPTION
## Description

Hotfix for cacophony-config to run syncing as root

## Testing

Have run locally to check it's able to write to config, will test on test cameras before PR to prod
