### PR TITLE
Update test r28

### DIFF
--- a/tc2/tc2-agent/init.sls
+++ b/tc2/tc2-agent/init.sls
@@ -1,7 +1,7 @@
 tc2-agent-pkg:
   cacophony.pkg_installed_from_github:
     - name: tc2-agent
-    - version: "0.5.16"
+    - version: "0.5.18"
     - architecture: "arm64"
     - branch: "main"
 

--- a/tc2/thermal-uploader/init.sls
+++ b/tc2/thermal-uploader/init.sls
@@ -1,7 +1,7 @@
 thermal-uploader-pkg:
   cacophony.pkg_installed_from_github:
     - name: thermal-uploader
-    - version: "2.7.3"
+    - version: "2.8.0"
     - architecture: "arm64"
     - branch: master
 


### PR DESCRIPTION
## Description

Fix is issues with TC2 agent losing audio files and with offload not being triggered correctly when flash is full.

## Testing

I tested it on my local device.
