### PR TITLE
Update test r29

### DIFF
--- a/tc2/tc2-agent/init.sls
+++ b/tc2/tc2-agent/init.sls
@@ -1,7 +1,7 @@
 tc2-agent-pkg:
   cacophony.pkg_installed_from_github:
     - name: tc2-agent
-    - version: "0.5.18"
+    - version: "0.5.19"
     - architecture: "arm64"
     - branch: "main"
 


### PR DESCRIPTION
## Description

Fixes an edge case issue where if you were in high power mode and you entered the thermal recording window and also your mode is audio and thermal, then it wouldn't set the next audio alarm.

## Testing

Tested on my device.
