### PR TITLE
Tc2 logging fix

### DIFF
--- a/tc2/tc2-agent/init.sls
+++ b/tc2/tc2-agent/init.sls
@@ -1,7 +1,7 @@
 tc2-agent-pkg:
   cacophony.pkg_installed_from_github:
     - name: tc2-agent
-    - version: "0.5.25"
+    - version: "0.5.26"
     - architecture: "arm64"
     - branch: "main"
 


### PR DESCRIPTION
## Description

- Fixes logging in tc2-firmware for corrupt or incomplete files failing offload.
- Small fix around restarting with audio files to offload in high-power mode.

## Testing

Tested that nothing breaks on my device.
