### PR TITLE
Fix high power audio restarting

### DIFF
--- a/tc2/tc2-agent/init.sls
+++ b/tc2/tc2-agent/init.sls
@@ -1,7 +1,7 @@
 tc2-agent-pkg:
   cacophony.pkg_installed_from_github:
     - name: tc2-agent
-    - version: "0.5.26"
+    - version: "0.5.27"
     - architecture: "arm64"
     - branch: "main"
 


### PR DESCRIPTION
## Description

rPi was incorrectly restarted in high power mode, regardless of whether it is within the current recording window.
This is now fixed.

## Testing

Tested on my device