### PR TITLE
Update test r36

### DIFF
--- a/tc2/tc2-agent/init.sls
+++ b/tc2/tc2-agent/init.sls
@@ -1,7 +1,7 @@
 tc2-agent-pkg:
   cacophony.pkg_installed_from_github:
     - name: tc2-agent
-    - version: "0.5.28"
+    - version: "0.5.29"
     - architecture: "arm64"
     - branch: "main"
 

--- a/tc2/tc2-hat-controller/init.sls
+++ b/tc2/tc2-hat-controller/init.sls
@@ -1,7 +1,7 @@
 tc2-hat-controller-pkg:
   cacophony.pkg_installed_from_github:
     - name: tc2-hat-controller
-    - version: "0.20.6"
+    - version: "0.20.7"
     - architecture: "arm64"
     - branch: "main"
 


### PR DESCRIPTION
## Description

- Fixes issue with offloads being incorrectly deleted when offload to pi failed many times.
- Fixes issue where attiny WDT may not get keep alive sent during busy periods of thermal recording, leading to restarts and possible file corruption.
- Fixes issue where rp2040 events were not offloaded until the event log is full in high-power mode.

## Testing

Tested using simulation of firmware, since these cases are not possible to deterministically trigger in hardware.