### PR TITLE
Update test fix r36

### DIFF
--- a/tc2/tc2-agent/init.sls
+++ b/tc2/tc2-agent/init.sls
@@ -1,7 +1,7 @@
 tc2-agent-pkg:
   cacophony.pkg_installed_from_github:
     - name: tc2-agent
-    - version: "0.5.29"
+    - version: "0.5.30"
     - architecture: "arm64"
     - branch: "main"
 


### PR DESCRIPTION
## Description

Fixes issue where we weren't handling file system errors correctly when looking for the existence of the file that tells us when the rp2040 was last reprogrammed.
